### PR TITLE
Fix meson setup failure not exiting build script when it should

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -113,12 +113,12 @@ jobs:
         repository: ["ZestCommunity/ZestCode"]
         ref: ["main"]
         caller_token: ["${{ github.token }}"]
-        clone_repo: [true, false] # false tests setup command
+        clone_repo: [true]
         expect_error: [false]
         include:
           # Specific case of setup command failure
           - write_job_summary: true
-            clone_repo: true
+            clone_repo: false
             expect_error: true
 
     with:

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -119,6 +119,7 @@ jobs:
           # Specific case of setup command failure
           - write_job_summary: true
             clone_repo: true
+            expect_error: true
 
     with:
       write_job_summary: ${{ matrix.write_job_summary }}

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -113,6 +113,13 @@ jobs:
         repository: ["ZestCommunity/ZestCode"]
         ref: ["main"]
         caller_token: ["${{ github.token }}"]
+        clone_repo: [true, false] # false tests setup command
+        expect_error: [false, true]
+      exclude:
+        # We only really need to test if the action fails the setup command in one case
+        - write_job_summary: false
+          clone_repo: false
+
     with:
       write_job_summary: ${{ matrix.write_job_summary }}
       repository: ${{ matrix.repository }}

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -114,17 +114,19 @@ jobs:
         ref: ["main"]
         caller_token: ["${{ github.token }}"]
         clone_repo: [true, false] # false tests setup command
-        expect_error: [false, true]
-      exclude:
-        # We only really need to test if the action fails the setup command in one case
-        - write_job_summary: false
-          clone_repo: false
+        expect_error: [false]
+        include:
+          # Specific case of setup command failure
+          - write_job_summary: true
+            clone_repo: true
 
     with:
       write_job_summary: ${{ matrix.write_job_summary }}
       repository: ${{ matrix.repository }}
       ref: ${{ matrix.ref }}
       caller_token: ${{ matrix.caller_token }}
+      clone_repo: ${{ matrix.clone_repo }}
+      expect_error: ${{ matrix.expect_error }}
 
   Upload_Image:
     name: Upload Docker Image to ghcr.io Registry

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,19 +18,28 @@ on:
         description: Whether to write the artifact URL to the job summary
         default: true
         type: boolean
+      clone_repo:
+        description: Whether to clone the repo
+        default: true
+        type: boolean
+      expect_error:
+        description: Whether to expect an error
+        default: false
+        type: boolean
 
 jobs:
   test:
     name: "Testing Container: Write Job Summary?${{ inputs.write_job_summary }}"
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout Repository to Test
         uses: actions/checkout@v4
+        if: ${{ inputs.clone_repo }}
         with:
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.ref }}
 
-      - name: Checkout
+      - name: Checkout Action
         uses: actions/checkout@v4
         with:
           path: ./action/
@@ -55,6 +64,16 @@ jobs:
       - name: Test Action
         id: test-action
         uses: ./action/
-        continue-on-error: False
+        continue-on-error: ${{ inputs.expect_error }}
         with:
           write_job_summary: ${{ inputs.write_job_summary }}
+      
+      - name: Check for Failure If Expected
+        if: ${{ inputs.expect_error }}        
+        run: |
+          if [ "${{ (steps.test-action.outcome == 'success') }}" == "true" ]; then
+            echo "Test Action step succeeded when it was expected to fail. Failing job.."
+            exit 1
+          else
+            echo "Test Action step failed as expected."
+          fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,15 @@ jobs:
     name: "Testing Container: Write Job Summary?${{ inputs.write_job_summary }}"
     runs-on: ubuntu-latest
     steps:
+      - name: Print Inputs
+        run: |
+          echo "Inputs(repository): ${{ inputs.repository }}"
+          echo "Inputs(ref): ${{ inputs.ref }}"
+          echo "Inputs(caller_token): ${{ inputs.caller_token }}"
+          echo "Inputs(write_job_summary): ${{ inputs.write_job_summary }}"
+          echo "Inputs(clone_repo): ${{ inputs.clone_repo }}"
+          echo "Inputs(expect_error): ${{ inputs.expect_error }}"
+
       - name: Checkout Repository to Test
         uses: actions/checkout@v4
         if: ${{ inputs.clone_repo }}

--- a/build-tools/build.sh
+++ b/build-tools/build.sh
@@ -35,19 +35,18 @@ echo "Meson setup exit code: $meson_exit_code"
 if [ $meson_exit_code -ne 0 ]; then
     echo "Meson setup failed. Please check the logs for more information."
   if [ "$INPUT_WRITE_JOB_SUMMARY" == "true" ]; then
-    {
-    echo "Meson setup failed. Please check the logs for more information.  " 
-    echo "***" 
-    echo "<details><summary>Click to expand</summary>  " 
-    echo "  " 
-    echo "\`\`\`  " 
-    echo "  " 
-    cat $COMPILE_STD_OUTPUT 
-    echo "  " 
-    echo "\`\`\`  " 
-    echo "  " 
-    echo "</details>  " 
-    } >> $GITHUB_STEP_SUMMARY
+    echo "# 🛑 Meson Setup Failed  " > $GITHUB_STEP_SUMMARY
+    echo "Meson setup failed. Please check the logs for more information.  " >> $GITHUB_STEP_SUMMARY
+    echo "***" >> $GITHUB_STEP_SUMMARY
+    echo "<details><summary>Click to expand</summary>  " >> $GITHUB_STEP_SUMMARY
+    echo "  " >> $GITHUB_STEP_SUMMARY
+    echo "\`\`\`  " >> $GITHUB_STEP_SUMMARY
+    echo "  " >> $GITHUB_STEP_SUMMARY
+    cat $COMPILE_STD_OUTPUT >> $GITHUB_STEP_SUMMARY
+    echo "  " >> $GITHUB_STEP_SUMMARY
+    echo "\`\`\`  " >> $GITHUB_STEP_SUMMARY
+    echo "  " >> $GITHUB_STEP_SUMMARY
+    echo "</details>  " >> $GITHUB_STEP_SUMMARY
   fi
   echo "::endgroup::"
   exit 1
@@ -75,25 +74,21 @@ STD_EDITED_OUTPUT=$(mktemp)
 sed -r "s/\x1B\[([0-9]{1,3}(;[0-9]{1,2};?)?)?[mGK]//g" $STD_OUTPUT >$STD_EDITED_OUTPUT
 
 if [ $meson_exit_code -ne 0 ]; then
-
   if [ "$INPUT_WRITE_JOB_SUMMARY" == "true" ]; then
-    {
-    echo "# 🛑 Meson Compile Failed  " 
-    echo "Meson compile failed in $elapsed_time seconds. Please check the logs for more information.  "
-    echo "***"
-    echo "<details><summary>Click to expand</summary>  "
-    echo "  "
-    echo "\`\`\`\n  "
-    echo "  "
-    cat $STD_EDITED_OUTPUT
-    echo "  "
-    echo "\`\`\`\n  "
-    echo "  "
-    echo "</details>  " 
-    }>> $GITHUB_STEP_SUMMARY
+    echo "Meson compile failed. Please check the logs for more information."
+    echo "# 🛑 Meson Compile Failed  " > $GITHUB_STEP_SUMMARY
+    echo "Meson compile failed in $elapsed_time seconds. Please check the logs for more information.  " >> $GITHUB_STEP_SUMMARY
+    echo "***" >> $GITHUB_STEP_SUMMARY
+    echo "<details><summary>Click to expand</summary>  " >> $GITHUB_STEP_SUMMARY
+    echo "  " >> $GITHUB_STEP_SUMMARY
+    echo "\`\`\`\n  " >> $GITHUB_STEP_SUMMARY
+    echo "  " >> $GITHUB_STEP_SUMMARY
+    cat $STD_EDITED_OUTPUT >> $GITHUB_STEP_SUMMARY
+    echo "  " >> $GITHUB_STEP_SUMMARY
+    echo "\`\`\`\n  " >> $GITHUB_STEP_SUMMARY
+    echo "  " >> $GITHUB_STEP_SUMMARY
+    echo "</details>  " >> $GITHUB_STEP_SUMMARY
   fi
-  echo "::endgroup::"
-  echo "Meson compile failed. Please check the above group for more information."
   exit 1
 fi
 echo "::endgroup::"
@@ -107,18 +102,16 @@ echo "The build took $elapsed_time seconds"
 
 # job summary
 if [ "$INPUT_WRITE_JOB_SUMMARY" == "true" ]; then
-  {
-  echo "# ✅ Build Successful  "
-  echo "The build was successful and took $elapsed_time seconds.  " 
-  echo "***" 
-  echo "<details><summary>Click to expand</summary>  " 
-  echo "  " 
-  echo "\`\`\`  " 
-  echo "  " 
-  cat $STD_EDITED_OUTPUT 
-  echo "  " 
-  echo "\`\`\`  " 
-  echo "  " 
-  echo "</details>  " 
-  } >> $GITHUB_STEP_SUMMARY
+  echo "# ✅ Build Successful  " > $GITHUB_STEP_SUMMARY
+  echo "The build was successful and took $elapsed_time seconds.  " >> $GITHUB_STEP_SUMMARY
+  echo "***" >> $GITHUB_STEP_SUMMARY
+  echo "<details><summary>Click to expand</summary>  " >> $GITHUB_STEP_SUMMARY
+  echo "  " >> $GITHUB_STEP_SUMMARY
+  echo "\`\`\`  " >> $GITHUB_STEP_SUMMARY
+  echo "  " >> $GITHUB_STEP_SUMMARY
+  cat $STD_EDITED_OUTPUT >> $GITHUB_STEP_SUMMARY
+  echo "  " >> $GITHUB_STEP_SUMMARY
+  echo "\`\`\`  " >> $GITHUB_STEP_SUMMARY
+  echo "  " >> $GITHUB_STEP_SUMMARY
+  echo "</details>  " >> $GITHUB_STEP_SUMMARY
 fi

--- a/build-tools/build.sh
+++ b/build-tools/build.sh
@@ -35,18 +35,19 @@ echo "Meson setup exit code: $meson_exit_code"
 if [ $meson_exit_code -ne 0 ]; then
     echo "Meson setup failed. Please check the logs for more information."
   if [ "$INPUT_WRITE_JOB_SUMMARY" == "true" ]; then
-    echo "# 🛑 Meson Setup Failed  " > $GITHUB_STEP_SUMMARY
-    echo "Meson setup failed. Please check the logs for more information.  " >> $GITHUB_STEP_SUMMARY
-    echo "***" >> $GITHUB_STEP_SUMMARY
-    echo "<details><summary>Click to expand</summary>  " >> $GITHUB_STEP_SUMMARY
-    echo "  " >> $GITHUB_STEP_SUMMARY
-    echo "\`\`\`  " >> $GITHUB_STEP_SUMMARY
-    echo "  " >> $GITHUB_STEP_SUMMARY
-    cat $COMPILE_STD_OUTPUT >> $GITHUB_STEP_SUMMARY
-    echo "  " >> $GITHUB_STEP_SUMMARY
-    echo "\`\`\`  " >> $GITHUB_STEP_SUMMARY
-    echo "  " >> $GITHUB_STEP_SUMMARY
-    echo "</details>  " >> $GITHUB_STEP_SUMMARY
+    {
+    echo "Meson setup failed. Please check the logs for more information.  " 
+    echo "***" 
+    echo "<details><summary>Click to expand</summary>  " 
+    echo "  " 
+    echo "\`\`\`  " 
+    echo "  " 
+    cat $COMPILE_STD_OUTPUT 
+    echo "  " 
+    echo "\`\`\`  " 
+    echo "  " 
+    echo "</details>  " 
+    } >> $GITHUB_STEP_SUMMARY
   fi
   echo "::endgroup::"
   exit 1
@@ -74,21 +75,25 @@ STD_EDITED_OUTPUT=$(mktemp)
 sed -r "s/\x1B\[([0-9]{1,3}(;[0-9]{1,2};?)?)?[mGK]//g" $STD_OUTPUT >$STD_EDITED_OUTPUT
 
 if [ $meson_exit_code -ne 0 ]; then
+
   if [ "$INPUT_WRITE_JOB_SUMMARY" == "true" ]; then
-    echo "Meson compile failed. Please check the logs for more information."
-    echo "# 🛑 Meson Compile Failed  " > $GITHUB_STEP_SUMMARY
-    echo "Meson compile failed in $elapsed_time seconds. Please check the logs for more information.  " >> $GITHUB_STEP_SUMMARY
-    echo "***" >> $GITHUB_STEP_SUMMARY
-    echo "<details><summary>Click to expand</summary>  " >> $GITHUB_STEP_SUMMARY
-    echo "  " >> $GITHUB_STEP_SUMMARY
-    echo "\`\`\`\n  " >> $GITHUB_STEP_SUMMARY
-    echo "  " >> $GITHUB_STEP_SUMMARY
-    cat $STD_EDITED_OUTPUT >> $GITHUB_STEP_SUMMARY
-    echo "  " >> $GITHUB_STEP_SUMMARY
-    echo "\`\`\`\n  " >> $GITHUB_STEP_SUMMARY
-    echo "  " >> $GITHUB_STEP_SUMMARY
-    echo "</details>  " >> $GITHUB_STEP_SUMMARY
+    {
+    echo "# 🛑 Meson Compile Failed  " 
+    echo "Meson compile failed in $elapsed_time seconds. Please check the logs for more information.  "
+    echo "***"
+    echo "<details><summary>Click to expand</summary>  "
+    echo "  "
+    echo "\`\`\`\n  "
+    echo "  "
+    cat $STD_EDITED_OUTPUT
+    echo "  "
+    echo "\`\`\`\n  "
+    echo "  "
+    echo "</details>  " 
+    }>> $GITHUB_STEP_SUMMARY
   fi
+  echo "::endgroup::"
+  echo "Meson compile failed. Please check the above group for more information."
   exit 1
 fi
 echo "::endgroup::"
@@ -102,16 +107,18 @@ echo "The build took $elapsed_time seconds"
 
 # job summary
 if [ "$INPUT_WRITE_JOB_SUMMARY" == "true" ]; then
-  echo "# ✅ Build Successful  " > $GITHUB_STEP_SUMMARY
-  echo "The build was successful and took $elapsed_time seconds.  " >> $GITHUB_STEP_SUMMARY
-  echo "***" >> $GITHUB_STEP_SUMMARY
-  echo "<details><summary>Click to expand</summary>  " >> $GITHUB_STEP_SUMMARY
-  echo "  " >> $GITHUB_STEP_SUMMARY
-  echo "\`\`\`  " >> $GITHUB_STEP_SUMMARY
-  echo "  " >> $GITHUB_STEP_SUMMARY
-  cat $STD_EDITED_OUTPUT >> $GITHUB_STEP_SUMMARY
-  echo "  " >> $GITHUB_STEP_SUMMARY
-  echo "\`\`\`  " >> $GITHUB_STEP_SUMMARY
-  echo "  " >> $GITHUB_STEP_SUMMARY
-  echo "</details>  " >> $GITHUB_STEP_SUMMARY
+  {
+  echo "# ✅ Build Successful  "
+  echo "The build was successful and took $elapsed_time seconds.  " 
+  echo "***" 
+  echo "<details><summary>Click to expand</summary>  " 
+  echo "  " 
+  echo "\`\`\`  " 
+  echo "  " 
+  cat $STD_EDITED_OUTPUT 
+  echo "  " 
+  echo "\`\`\`  " 
+  echo "  " 
+  echo "</details>  " 
+  } >> $GITHUB_STEP_SUMMARY
 fi

--- a/build-tools/build.sh
+++ b/build-tools/build.sh
@@ -30,7 +30,6 @@ git config --global --add safe.directory /github/workspace
 COMPILE_STD_OUTPUT=$(mktemp)
 echo "::group::Build Project"
 meson setup --cross-file scripts/v5.ini build | tee $COMPILE_STD_OUTPUT
-echo "PIPESTATUS: ${PIPESTATUS[@]}"
 meson_exit_code=${PIPESTATUS[0]}
 echo "Meson setup exit code: $meson_exit_code"
 if [ $meson_exit_code -ne 0 ]; then


### PR DESCRIPTION
Fixes #3 

> Given the following block of code:
> 
> COMPILE_STD_OUTPUT=$(mktemp)
> echo "::group::Build Project"
> meson setup --cross-file scripts/v5.ini build | tee $COMPILE_STD_OUTPUT
> meson_exit_code=${PIPESTATUS[0]}
> echo "PIPESTATUS: ${PIPESTATUS[@]}"
> echo "Meson setup exit code: $meson_exit_code"
> if [ $meson_exit_code -ne 0 ]; then
>     echo "Meson setup failed. Please check the logs for more information."
>   if [ "$INPUT_WRITE_JOB_SUMMARY" == "true" ]; then
>     {
>     echo "Meson setup failed. Please check the logs for more information.  " 
>     echo "***" 
>     echo "<details><summary>Click to expand</summary>  " 
>     echo "  " 
>     echo "\`\`\`  " 
>     echo "  " 
>     cat $COMPILE_STD_OUTPUT 
>     echo "  " 
>     echo "\`\`\`  " 
>     echo "  " 
>     echo "</details>  " 
>     } >> $GITHUB_STEP_SUMMARY
>   fi
>   echo "::endgroup::"
>   exit 1
> fi
> echo "::endgroup::"
> this line
> 
> > `echo "PIPESTATUS: ${PIPESTATUS[@]}"` was for some reason causing setup failures to not actually exit the build.sh script when they should
> 
> ## Fixes
> * [x]  Remove this line
> * [x]  Add tests to prevent this in the future

